### PR TITLE
Szybki bug fix

### DIFF
--- a/src/main/java/pl/edu/pwr/student/UI/Buttons/AddButton.java
+++ b/src/main/java/pl/edu/pwr/student/UI/Buttons/AddButton.java
@@ -45,6 +45,10 @@ public class AddButton extends Button {
             }
         }
         Form form = sketch.saveCompoundGateDialog();
-        DataWriter.saveToFileCompoundGate(sketch, form.getByLabel("Name of the gate").asString(), form.getByLabel("Message for the gate").asString());
+        try {
+            DataWriter.saveToFileCompoundGate(sketch, form.getByLabel("Name of the gate").asString(), form.getByLabel("Message for the gate").asString());
+        } catch (RuntimeException e) {
+            sketch.showPopup("VirtualIO inputs/outputs must have unique names");
+        }
     }
 }

--- a/src/main/java/pl/edu/pwr/student/UI/Canvas.java
+++ b/src/main/java/pl/edu/pwr/student/UI/Canvas.java
@@ -159,9 +159,7 @@ public class Canvas extends PApplet {
     public void draw() {
         background(255);
 
-        for (int i = 0; i < elements.size(); i++) {
-            elements.get(i).run();
-        }
+        for (Drawable element : elements) element.run();
 
         if (elements.isEmpty()) {
             fill(0);
@@ -174,9 +172,7 @@ public class Canvas extends PApplet {
             );
         }
 
-        for (int i = 0; i < buttons.size(); i++) {
-            buttons.get(i).run();
-        }
+        for (Button button : buttons) button.run();
     }
 
     /**
@@ -185,10 +181,10 @@ public class Canvas extends PApplet {
     @Override
     public void mousePressed() {
         PVector mouse = new PVector(mouseX, mouseY);
-        for (int i = 0; i < buttons.size(); i++) {
-            if(buttons.get(i).over(mouse)) {
+        for (Button button : buttons) {
+            if (button.over(mouse)) {
                 try {
-                    buttons.get(i).click();
+                    button.click();
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }

--- a/src/main/java/pl/edu/pwr/student/Utility/FileManagement/DataWriter.java
+++ b/src/main/java/pl/edu/pwr/student/Utility/FileManagement/DataWriter.java
@@ -48,9 +48,8 @@ public class DataWriter {
     public static void saveToFileCompoundGate(Canvas canvas, String name, String message) throws IOException {
         File directory = new File("gates");
 
-        if (!directory.exists()) {
+        if (!directory.exists())
             directory.mkdir();
-        }
 
         if(name.length()==0)
             name = "Custom_gate";
@@ -59,23 +58,31 @@ public class DataWriter {
         if(message.length()==0)
             message = "Custom_gate_message";
 
-        File file = new File(directory.getAbsoluteFile() + "\\" + name + ".gss");
-        BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter(file.getAbsoluteFile()));
-
-
-
         HashSet<Compoundable> basicGates = new HashSet<>();
         HashSet<CompoundGate> compGates = new HashSet<>();
 
         for (Drawable drawable:canvas.getElements()) {
-            if(Objects.equals(drawable.getGate().getClass(), CompoundGate.class)){
+            if(Objects.equals(drawable.getGate().getClass(), CompoundGate.class))
                 compGates.add((CompoundGate) drawable.getGate());
-            }
-            else{
+            else
                 basicGates.add((Compoundable) drawable.getGate());
-            }
         }
-        CompoundGate compoundGate = new CompoundGate(name,message,basicGates,compGates);
+
+        CompoundGate compoundGate = null;
+
+        try {
+            compoundGate = new CompoundGate(name, message, basicGates, compGates);
+        } catch (Exception ignored) {}
+
+        File file;
+        BufferedWriter bufferedWriter;
+
+        if (compoundGate != null) {
+            file = new File(directory.getAbsoluteFile() + "\\" + name + ".gss");
+            bufferedWriter = new BufferedWriter(new FileWriter(file.getAbsoluteFile()));
+        } else {
+            throw new RuntimeException("CompoundGate VirtualIO names are not unique");
+        }
 
         bufferedWriter.write(DataWriter.generateJSONFromCompoundGate(compoundGate));
 


### PR DESCRIPTION
Próba zapisania CompoundGate, którego VirtualIO miały takie same nazwy skutkowała stworzeniem pustego pliku zapisu i natychmiastowym jego wczytaniem, zawieszało to program i uniemożliwiało jego późniejsze uruchomienie. Teraz nic się złego nie dzieje i jest tylko wyświetlane powiadomienie, że tak nie wolno.